### PR TITLE
Migrate to x.com from twitter.com except embed post

### DIFF
--- a/src/components/tweet.tsx
+++ b/src/components/tweet.tsx
@@ -17,5 +17,5 @@ const generateEmbedHtml = (tweetId: string): string => {
     throw new Error(`Invalid tweet ID: ${tweetId}`)
   }
 
-  return `<blockquote class="twitter-tweet"><a href="https://x.com/i/status/${tweetId}"></a></blockquote>`
+  return `<blockquote class="twitter-tweet"><a href="https://twitter.com/i/status/${tweetId}"></a></blockquote>`
 }

--- a/src/components/tweet.tsx
+++ b/src/components/tweet.tsx
@@ -17,5 +17,5 @@ const generateEmbedHtml = (tweetId: string): string => {
     throw new Error(`Invalid tweet ID: ${tweetId}`)
   }
 
-  return `<blockquote class="twitter-tweet"><a href="https://twitter.com/i/status/${tweetId}"></a></blockquote>`
+  return `<blockquote class="twitter-tweet"><a href="https://x.com/i/status/${tweetId}"></a></blockquote>`
 }

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -65,7 +65,7 @@ export default function AboutPage() {
             <TableRow>
               <TableCell>X (Twitter)</TableCell>
               <TableCell>
-                <NextLink href='https://twitter.com/aoirint' passHref legacyBehavior>
+                <NextLink href='https://x.com/aoirint' passHref legacyBehavior>
                   <MuiLink>@aoirint</MuiLink>
                 </NextLink>
               </TableCell>

--- a/src/pages/person/[personId]/index.tsx
+++ b/src/pages/person/[personId]/index.tsx
@@ -71,7 +71,7 @@ export default function PersonPage({ person }: InferGetStaticPropsType<typeof ge
                     >
                       <TableCell component='th' scope='row'>
                         <NextLink
-                          href={`https://twitter.com/intent/user?user_id=${personTwitterAccount.twitterAccount.remoteTwitterUserId}`}
+                          href={`https://x.com/intent/user?user_id=${personTwitterAccount.twitterAccount.remoteTwitterUserId}`}
                           passHref
                           legacyBehavior
                         >

--- a/src/pages/privacy_policy/index.tsx
+++ b/src/pages/privacy_policy/index.tsx
@@ -168,7 +168,7 @@ export default function PrivacyPolicyPage() {
         </Typography>
         <Typography sx={{ mt: 2 }}>
           X（Twitter）によるデータ収集や処理についての詳細は、「
-          <NextLink href='https://twitter.com/privacy' passHref legacyBehavior>
+          <NextLink href='https://x.com/privacy' passHref legacyBehavior>
             <MuiLink>X（Twitter）のプライバシーポリシー</MuiLink>
           </NextLink>
           」をご参照ください。


### PR DESCRIPTION
埋め込みポストツールが生成するURLはまだ`twitter.com`で、`x.com`ではまだ動作しないようなので、そのままにします。